### PR TITLE
feat: create efp list interaction

### DIFF
--- a/src/app/editor/create-or-update-efp-list/index.tsx
+++ b/src/app/editor/create-or-update-efp-list/index.tsx
@@ -6,7 +6,7 @@ import { SelectChainCard } from './select-chain-card'
 import { Step } from './types'
 import { InitiateActionsCard } from './initiate-actions-card'
 import { TransactionStatusCard } from './transaction-status-card'
-// import { useCreateEFPList } from '#/hooks/efp-actions/use-create-efp-list'
+import { useCreateEFPList } from '#/hooks/efp-actions/use-create-efp-list'
 import { EFPActionType, type Action, useActions } from '#/contexts/actions-context'
 import { parseEther } from 'viem'
 import { useAccount, useChains } from 'wagmi'
@@ -38,7 +38,7 @@ export function CreateOrUpdateEFPList({ setOpen }: CreateOrUpdateEFPListProps) {
   })
 
   // Prepare action functions
-  // const { createEFPList } = useCreateEFPList({ chainId: selectedChain?.id })
+  const { createEFPList } = useCreateEFPList({ listStorageLocationChainId: selectedChain?.id })
 
   useEffect(() => {
     if (!selectedChainId) return
@@ -49,7 +49,7 @@ export function CreateOrUpdateEFPList({ setOpen }: CreateOrUpdateEFPListProps) {
       type: EFPActionType.UpdateEFPList,
       label: `${totalCartItems} edits to List Records`,
       chainId: selectedChainId,
-      execute: sendEth,
+      execute: createEFPList,
       isPendingConfirmation: false
     }
 
@@ -63,7 +63,7 @@ export function CreateOrUpdateEFPList({ setOpen }: CreateOrUpdateEFPListProps) {
     }
     const actions = hasCreatedEfpList ? [cartItemAction] : [createEFPListAction, cartItemAction]
     addActions(actions)
-  }, [selectedChainId, totalCartItems, addActions, sendEth])
+  }, [selectedChainId, totalCartItems, addActions, sendEth, createEFPList])
 
   // Handle selecting a chain
   const handleChainClick = useCallback((chainId: number) => {

--- a/src/app/efp/types.ts
+++ b/src/app/efp/types.ts
@@ -1,6 +1,10 @@
+/**
+ * The list storage location type to encode for storing an efp list within the efp list registry contract
+ * https://docs.ethfollow.xyz/design/list-storage-location/
+ */
 export type ListStorageLocation = {
-  version: number // 0-255
-  locationType: number // 0-255
+  version: 1 // 0-255, but currently only supporting 1
+  locationType: 1 // 0-255, but currently only supporting 1
   data: Uint8Array
 }
 

--- a/src/hooks/efp-actions/use-create-efp-list.ts
+++ b/src/hooks/efp-actions/use-create-efp-list.ts
@@ -1,10 +1,10 @@
 import type { ListStorageLocation } from '#/app/efp/types'
 import { generateListStorageLocationSlot } from '#/app/efp/utilities'
 import { efpListRegistryAbi } from '#/lib/abi'
-import { efpContracts } from '#/lib/constants/contracts'
+import { EFPListRegistryDeployChain, efpContracts } from '#/lib/constants/contracts'
 import { useCallback, useMemo } from 'react'
 import { encodePacked } from 'viem'
-import { foundry, mainnet } from 'viem/chains'
+import { mainnet } from 'viem/chains'
 import { useChainId, useSimulateContract, useSwitchChain, useWriteContract } from 'wagmi'
 
 /**
@@ -19,8 +19,6 @@ export const useCreateEFPList = ({
   listStorageLocationChainId = mainnet.id
 }: { listStorageLocationChainId: number | undefined }) => {
   const currentChainId = useChainId()
-  // Use the mainnet chain ID if we're not testing, otherwise use the foundry chain ID
-  const mainnetChainId = currentChainId === foundry.id ? foundry.id : mainnet.id
   const { switchChain } = useSwitchChain()
 
   // EFP List Storage Location version value, which is currently always 1
@@ -66,9 +64,9 @@ export const useCreateEFPList = ({
     if (!listStorageLocationChainId)
       throw new Error('listStorageLocationChainId is required to create an EFP list.')
 
-    // Switch chain to mainnet since the EFP List Registry contract is only deployed on mainnet
-    if (currentChainId !== mainnetChainId) {
-      switchChain({ chainId: mainnetChainId })
+    // Switch chain to mainnet (or foundry if in dev) since the EFP List Registry contract is only deployed on mainnet
+    if (currentChainId !== EFPListRegistryDeployChain) {
+      switchChain({ chainId: EFPListRegistryDeployChain })
     }
 
     // Handle no simulated data and/or error
@@ -82,8 +80,7 @@ export const useCreateEFPList = ({
     simulateCreateEFPListData?.request,
     switchChain,
     writeContractAsync,
-    listStorageLocationChainId,
-    mainnetChainId
+    listStorageLocationChainId
   ])
 
   return {

--- a/src/hooks/efp-actions/use-create-efp-list.ts
+++ b/src/hooks/efp-actions/use-create-efp-list.ts
@@ -67,8 +67,8 @@ export const useCreateEFPList = ({
       throw new Error('listStorageLocationChainId is required to create an EFP list.')
 
     // Switch chain to mainnet since the EFP List Registry contract is only deployed on mainnet
-    if (currentChainId !== mainnet.id) {
-      switchChain({ chainId: mainnet.id })
+    if (currentChainId !== mainnetChainId) {
+      switchChain({ chainId: mainnetChainId })
     }
 
     // Handle no simulated data and/or error
@@ -82,7 +82,8 @@ export const useCreateEFPList = ({
     simulateCreateEFPListData?.request,
     switchChain,
     writeContractAsync,
-    listStorageLocationChainId
+    listStorageLocationChainId,
+    mainnetChainId
   ])
 
   return {

--- a/src/hooks/efp-actions/use-create-efp-list.ts
+++ b/src/hooks/efp-actions/use-create-efp-list.ts
@@ -1,3 +1,4 @@
+import type { ListStorageLocation } from '#/app/efp/types'
 import { generateListStorageLocationSlot } from '#/app/efp/utilities'
 import { efpListRegistryAbi } from '#/lib/abi'
 import { efpContracts } from '#/lib/constants/contracts'
@@ -5,15 +6,32 @@ import { useCallback, useMemo } from 'react'
 import { encodePacked } from 'viem'
 import { useChainId, useSimulateContract, useSwitchChain, useWriteContract } from 'wagmi'
 
+// Chain ID to use when no chain ID is provided
 const NO_CHAIN_ID = 0
 
+/**
+ * @description Create an EFP list by calling the mint function on the EFPListRegistry contract
+ * This mints an nft to the user while setting the EFP list storage location
+ * The List Storage Location value is stored in the main EFP List Registry contract and can be changed at any time by the EFP List NFT owner.
+ * @param param0
+ * @returns
+ */
 export const useCreateEFPList = ({ chainId }: { chainId: number | undefined }) => {
   const currentChainId = useChainId()
   const chainIdToUseForCreate = chainId || NO_CHAIN_ID
   const { switchChain } = useSwitchChain()
 
-  // Keep the same nonce between renders
-  const nonce = useMemo(() => generateListStorageLocationSlot(), [])
+  // EFP List Storage Location version value, which is currently always 1
+  const version: ListStorageLocation['version'] = 1
+  // EFP List Storage Location locationType value, which is currently always 1
+  const locationType: ListStorageLocation['locationType'] = 1
+  // Keep the slot the same between renders
+  const slot = useMemo(() => generateListStorageLocationSlot(), [])
+
+  const listStorageLocation = encodePacked(
+    ['uint8', 'uint8', 'uint256', 'address', 'uint'],
+    [version, locationType, BigInt(chainIdToUseForCreate), efpContracts['EFPListRecords'], slot]
+  )
 
   // Simulate the creation of an EFP list
   // If there's no chain ID, supply an invalid chain id (NO_CHAIN_ID) to force an error
@@ -26,12 +44,7 @@ export const useCreateEFPList = ({ chainId }: { chainId: number | undefined }) =
     address: efpContracts['EFPListRegistry'],
     abi: efpListRegistryAbi,
     functionName: 'mint',
-    args: [
-      encodePacked(
-        ['uint8', 'uint8', 'uint256', 'address', 'uint'],
-        [1, 1, BigInt(chainIdToUseForCreate), efpContracts['EFPListRecords'], nonce]
-      )
-    ]
+    args: [listStorageLocation]
   })
 
   const {

--- a/src/hooks/efp-contract-reads/use-list-registry.ts
+++ b/src/hooks/efp-contract-reads/use-list-registry.ts
@@ -1,0 +1,55 @@
+import { efpListRegistryAbi } from '#/lib/abi'
+import { EFPListRegistryDeployChain, efpContracts } from '#/lib/constants/contracts'
+import { useMemo } from 'react'
+import { zeroAddress, type Address } from 'viem'
+import { useReadContract } from 'wagmi'
+
+interface UseListRegistryData {
+  numTokens: bigint | undefined // the number of nft's for the specified address in the EFP List Registry
+  tokenIds: readonly bigint[] | undefined // the token ids for the specified owner in the EFP List Registry
+  tokenIdsIsLoading: boolean
+  tokenIdsIsError: boolean
+  primaryListTokenId: bigint | undefined // the primary list token id for the specified address in the EFP List Registry
+  hasPrimaryListTokenId: boolean
+}
+
+/**
+ * @description Get EFP List Registry contract data pertaining to the specified address
+ * @param address The address to use
+ * @returns
+ */
+const useListRegistry = (ownerAddress: Address | undefined) => {
+  const { data: numTokens } = useReadContract({
+    address: efpContracts.EFPListRegistry,
+    abi: efpListRegistryAbi,
+    functionName: 'balanceOf',
+    args: [ownerAddress || zeroAddress],
+    chainId: EFPListRegistryDeployChain
+  })
+
+  const {
+    data: tokenIds,
+    isLoading: tokenIdsIsLoading,
+    isError: tokenIdsIsError
+  } = useReadContract({
+    address: efpContracts.EFPListRegistry,
+    abi: efpListRegistryAbi,
+    functionName: 'tokensOfOwner',
+    args: [ownerAddress || zeroAddress]
+  })
+
+  // Get the primary list token id
+  // TODO get the primary list token id from the EFPAccountMetadata contract; assuming the primary list token id is the first token id in the list for now
+  const primaryListTokenId = tokenIds?.[0]
+
+  return {
+    numTokens,
+    tokenIds,
+    tokenIdsIsLoading,
+    tokenIdsIsError,
+    primaryListTokenId,
+    hasPrimaryListTokenId: tokenIds?.[0] !== undefined
+  } satisfies UseListRegistryData
+}
+
+export default useListRegistry

--- a/src/hooks/efp-contract-reads/use-list-storage-location.ts
+++ b/src/hooks/efp-contract-reads/use-list-storage-location.ts
@@ -1,0 +1,35 @@
+import { efpListRegistryAbi } from '#/lib/abi'
+import { EFPListRegistryDeployChain, efpContracts } from '#/lib/constants/contracts'
+import { zeroAddress } from 'viem'
+import { useAccount, useReadContract } from 'wagmi'
+
+/**
+ * @description Gets the EFP list storage location for the fetched token ID
+ */
+const useListStorageLocation = () => {
+  const { address: account } = useAccount()
+
+  // Fetch the tokenId associated with this account
+  const { data: nftData } = useReadContract({
+    address: efpContracts.EFPListRegistry,
+    abi: efpListRegistryAbi,
+    functionName: 'balanceOf',
+    args: [account || zeroAddress],
+    chainId: EFPListRegistryDeployChain
+  })
+
+  const tokenId = BigInt(0)
+  console.log('🦄 ~ useListStorageLocation ~ nftData:', nftData)
+
+  const { data, isLoading, isError } = useReadContract({
+    address: efpContracts.EFPListRegistry,
+    abi: efpListRegistryAbi,
+    functionName: 'getListStorageLocation',
+    args: [tokenId],
+    chainId: EFPListRegistryDeployChain
+  })
+
+  return { data, isLoading, isError }
+}
+
+export default useListStorageLocation

--- a/src/lib/constants/contracts.ts
+++ b/src/lib/constants/contracts.ts
@@ -1,4 +1,5 @@
 import type { Address } from '#/lib/types.ts'
+import { foundry, mainnet } from 'viem/chains'
 
 export const efpContracts: {
   EFPAccountMetadata: Address
@@ -11,3 +12,8 @@ export const efpContracts: {
   EFPListRecords: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
   EFPListMinter: '0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9'
 }
+
+// The chain ID of the EFP List Registry contract
+// This is the chain ID that the EFP List Registry contract is deployed on, assuming that during development it is deployed on the foundry chain
+export const EFPListRegistryDeployChain =
+  process.env.NODE_ENV === 'production' ? mainnet.id : foundry.id


### PR DESCRIPTION
`use-create-efp-list` hook to handle creating an efp list (mint efp list nft) within the `CreateOrUpdateEFPList` component.

Also includes a `use-list-registry` hook to start fetching any data related to the list registry for a given user (if applicable).

### TODO

Fix the build errors.