### PR TITLE
Persist cart items

### DIFF
--- a/src/app/editor/page.tsx
+++ b/src/app/editor/page.tsx
@@ -29,10 +29,12 @@ export default function EditorPage() {
 
   const profiles = useMemo(
     () =>
-      cartAddresses.map(address => ({
-        address,
-        tags: []
-      })),
+      isConnected
+        ? cartAddresses.map(address => ({
+            address,
+            tags: []
+          }))
+        : [],
     [cartAddresses]
   )
 

--- a/src/contexts/efp-profile-context.tsx
+++ b/src/contexts/efp-profile-context.tsx
@@ -55,6 +55,8 @@ export const EFPProfileProvider: React.FC<Props> = ({ children }) => {
   })
 
   useEffect(() => {
+    const cartAddress = localStorage.getItem('cart address')
+    if (userAddress?.toLowerCase() === cartAddress?.toLowerCase() || !userAddress) return
     resetCart()
   }, [userAddress])
 


### PR DESCRIPTION
Transform cart buffer data and store it into local storage, then restructure into listOps and add to cart upon logging in with the same addres. When changing the address the cart items get cleared out.