### PR TITLE
Profile recommendations

### DIFF
--- a/src/app/[user]/page.tsx
+++ b/src/app/[user]/page.tsx
@@ -11,8 +11,10 @@ import { PROFILE_TABS } from '#/lib/constants'
 import type { ProfileTabType } from '#/types/common'
 import ListSettings from '#/components/list-settings'
 import BlockedMuted from '#/components/blocked-muted'
+import { useIsEditView } from '#/hooks/use-is-edit-view'
 import SettingsIcon from 'public/assets/icons/settings.svg'
 import UserProfileCard from '#/components/user-profile-card'
+import { nullFollowingTags } from '#/api/fetchFollowingTags'
 import { useEFPProfile } from '#/contexts/efp-profile-context'
 import type { ProfileDetailsResponse } from '#/types/requests'
 import { UserProfilePageTable } from '#/components/profile-page-table'
@@ -68,10 +70,7 @@ export default function UserPage({ params }: Props) {
     isFetchingMoreFollowing: profileIsFetchingMoreFollowing
   } = useEFPProfile()
 
-  const isMyProfile: boolean =
-    (pathname?.toLowerCase() === `/${connectedUserAddress?.toLowerCase()}` &&
-      selectedList === Number(profileProfile?.primary_list)) ||
-    pathname === `/${selectedList?.toString() ?? connectedUserAddress}`
+  const isMyProfile = useIsEditView()
 
   const {
     listNum,
@@ -108,9 +107,13 @@ export default function UserPage({ params }: Props) {
     : userProfile
   const profileIsLoading =
     isLoadPage || (isMyProfile ? profileProfileIsLoading : userProfileIsLoading)
-  const following = isMyProfile ? profileFollowing : userFollowing
+  const following = isMyProfile ? (selectedList ? profileFollowing : []) : userFollowing
   const followers = isMyProfile ? profileFollowers : userFollowers
-  const followingTags = isMyProfile ? profileFollowingTags : userFollowingTags
+  const followingTags = isMyProfile
+    ? selectedList
+      ? profileFollowingTags
+      : nullFollowingTags
+    : userFollowingTags
   const followingTagsLoading =
     isLoadPage || (isMyProfile ? profileFollowingTagsLoading : userFollowingTagsLoading)
   const followingTagsFilter = isMyProfile ? profileFollowingTagsFilter : userFollowingTagsFilter

--- a/src/components/blocked-muted/index.tsx
+++ b/src/components/blocked-muted/index.tsx
@@ -5,8 +5,10 @@ import { useClickAway } from '@uidotdev/usehooks'
 
 import Cross from 'public/assets/icons/cross.svg'
 import { BLOCKED_MUTED_TABS } from '#/lib/constants'
+import { useIsEditView } from '#/hooks/use-is-edit-view'
 import type { BlockedMutedTabType } from '#/types/common'
 import { UserProfilePageTable } from '../profile-page-table'
+import { useEFPProfile } from '#/contexts/efp-profile-context'
 import type { ProfileDetailsResponse } from '#/types/requests'
 import useBlockedMuted, { EMPTY_COUNT_TAGS, TAGS } from './hooks/use-blocked-muted'
 
@@ -23,6 +25,9 @@ const BlockedMuted: React.FC<BlockedMutedProps> = ({ profile, list, isManager, o
   const blockedMutedRef = useClickAway<HTMLDivElement>(() => {
     onClose()
   })
+
+  const isMyProfile = useIsEditView()
+  const { selectedList } = useEFPProfile()
 
   const {
     blocking,
@@ -51,8 +56,18 @@ const BlockedMuted: React.FC<BlockedMutedProps> = ({ profile, list, isManager, o
 
   const filteredBlockingTags = blockingTags?.tagCounts?.filter(tag => TAGS.includes(tag.tag)) || []
   const displayedBlockingTags = [
-    { tag: 'All', count: filteredBlockingTags?.reduce((acc, tag) => acc + tag.count, 0) },
-    ...(filteredBlockingTags.length > 0 ? filteredBlockingTags : EMPTY_COUNT_TAGS)
+    {
+      tag: 'All',
+      count:
+        isMyProfile && !selectedList
+          ? 0
+          : filteredBlockingTags?.reduce((acc, tag) => acc + tag.count, 0)
+    },
+    ...(filteredBlockingTags.length > 0
+      ? isMyProfile && !selectedList
+        ? EMPTY_COUNT_TAGS
+        : filteredBlockingTags
+      : EMPTY_COUNT_TAGS)
   ]
 
   const filteredBlockedByTags =
@@ -62,11 +77,13 @@ const BlockedMuted: React.FC<BlockedMutedProps> = ({ profile, list, isManager, o
     ...(filteredBlockedByTags.length > 0 ? filteredBlockedByTags : EMPTY_COUNT_TAGS)
   ]
 
+  const displayedBlocking = isMyProfile && !selectedList ? [] : blocking
+
   const mobileActiveEl = {
     'Blocked/Muted': (
       <UserProfilePageTable
         isLoading={blockingIsLoading}
-        results={blocking}
+        results={displayedBlocking}
         allTags={displayedBlockingTags}
         tagsLoading={blockingTagsLoading}
         selectedTags={blockingTagsFilter}
@@ -119,7 +136,7 @@ const BlockedMuted: React.FC<BlockedMutedProps> = ({ profile, list, isManager, o
         <div className='bg-white/80 h-fit rounded-2xl w-full hidden xl:block'>
           <UserProfilePageTable
             isLoading={blockingIsLoading}
-            results={blocking}
+            results={displayedBlocking}
             allTags={displayedBlockingTags}
             tagsLoading={blockingTagsLoading}
             selectedTags={blockingTagsFilter}

--- a/src/components/profile-page-table/index.tsx
+++ b/src/components/profile-page-table/index.tsx
@@ -10,11 +10,13 @@ import type {
   FollowerResponse,
   FollowingResponse
 } from '#/types/requests'
+import Recommendations from '../recommendations'
 import { FETCH_LIMIT_PARAM } from '#/lib/constants'
 import TableHeader from './components/table-headers'
 import { FollowList } from '#/components/follow-list'
 import { useIsEditView } from '#/hooks/use-is-edit-view'
 import type { ProfileTableTitleType } from '#/types/common'
+import { useEFPProfile } from '#/contexts/efp-profile-context'
 
 /**
  * TODO: paginate
@@ -63,6 +65,7 @@ export function UserProfilePageTable({
     if (!showTags) setSelectedTags(isShowingBlocked ? ['All'] : [])
   }, [showTags])
 
+  const { lists } = useEFPProfile()
   const isProfile = useIsEditView()
   const { t } = useTranslation('profile')
 
@@ -148,21 +151,30 @@ export function UserProfilePageTable({
       {!isLoading && results?.length === 0 && (
         <div className='text-center font-semibold py-4'>{noResults}</div>
       )}
-      <FollowList
-        isLoading={isLoading}
-        isLoadingMore={isFetchingMore}
-        loadingRows={FETCH_LIMIT_PARAM}
-        listClassName='gap-2 rounded-xl w-full'
-        listItemClassName='rounded-xl w-full hover:bg-white/50 px-0 py-2 sm:p-2'
-        profiles={profiles}
-        showTags={showTags}
-        showFollowsYouBadges={showFollowsYouBadges}
-        canEditTags={canEditTags}
-        isFollowers={title === 'followers' || title === 'Blocked/Muted By'}
-        isBlockedList={isShowingBlocked}
-        isBlockedBy={title === 'Blocked/Muted By' && isProfile}
-      />
-      <div ref={loadMoreRef} className='h-px w-full' />
+      <div className='flex flex-col pb-4'>
+        <FollowList
+          isLoading={isLoading}
+          isLoadingMore={isFetchingMore}
+          loadingRows={FETCH_LIMIT_PARAM}
+          listClassName='gap-2 rounded-xl w-full'
+          listItemClassName='rounded-xl w-full hover:bg-white/50 px-0 py-2 sm:p-2'
+          profiles={profiles}
+          showTags={showTags}
+          showFollowsYouBadges={showFollowsYouBadges}
+          canEditTags={canEditTags}
+          isFollowers={title === 'followers' || title === 'Blocked/Muted By'}
+          isBlockedList={isShowingBlocked}
+          isBlockedBy={title === 'Blocked/Muted By' && isProfile}
+        />
+        <div ref={loadMoreRef} className='h-px w-full' />
+        {title === 'following' && isProfile && lists?.lists && lists.lists.length === 0 && (
+          <Recommendations
+            endpoint='recommended'
+            description='Those are recommended profiles and not people you follow'
+            className='p-2'
+          />
+        )}
+      </div>
     </div>
   )
 }

--- a/src/components/recommendations.tsx
+++ b/src/components/recommendations.tsx
@@ -8,13 +8,20 @@ import { FollowList } from '#/components/follow-list'
 import fetchRecommendations from '#/api/fetchRecommendations'
 
 interface RecommendationsProps {
-  header: string
+  header?: string
+  description?: string
   className?: string
   limit?: number
   endpoint: 'discover' | 'recommended'
 }
 
-const Recommendations = ({ header, className, limit, endpoint }: RecommendationsProps) => {
+const Recommendations = ({
+  header,
+  description,
+  className,
+  limit,
+  endpoint
+}: RecommendationsProps) => {
   const { address: userAddress } = useAccount()
   const { data: profilesToRecommend, isLoading } = useQuery({
     queryKey: [endpoint, userAddress],
@@ -31,7 +38,10 @@ const Recommendations = ({ header, className, limit, endpoint }: Recommendations
 
   return (
     <div className={clsx('flex flex-col gap-8', className)}>
-      <h2 className='text-center lg:text-start text-3xl font-bold'>{header}</h2>
+      <div>
+        <h2 className='text-center lg:text-start text-3xl font-bold'>{header}</h2>
+        <p className='text-center text-xs text-gray-400 italic font-medium'>{description}</p>
+      </div>
       <FollowList
         isLoading={isLoading}
         loadingRows={limit}

--- a/src/components/user-profile-card/index.tsx
+++ b/src/components/user-profile-card/index.tsx
@@ -80,7 +80,9 @@ const UserProfileCard: React.FC<UserProfileCardProps> = ({
   const isConnectedUserCard =
     pathname === '/' ||
     (pathname?.toLowerCase() === `/${connectedAddress?.toLowerCase()}` &&
-      selectedList === Number(profile?.primary_list)) ||
+      (profile?.primary_list && selectedList
+        ? selectedList === Number(profile?.primary_list)
+        : true)) ||
     pathname === `/${selectedList?.toString() ?? connectedAddress}`
 
   const isProfileValid = !(
@@ -190,7 +192,11 @@ const UserProfileCard: React.FC<UserProfileCardProps> = ({
       ) : profile && isProfileValid ? (
         <>
           <div className='flex gap-2 items-center absolute justify-between px-2 w-full left-0 top-1 font-semibold'>
-            {profileList && <p className='text-gray-500 text-sm sm:text-base'>#{profileList}</p>}
+            {(isConnectedUserCard ? selectedList : profileList) && (
+              <p className='text-gray-500 text-sm sm:text-base'>
+                #{isConnectedUserCard ? selectedList : profileList}
+              </p>
+            )}
             {profileList
               ? profileList !== Number(profile.primary_list) && (
                   <p className='text-[11px] italic text-end rounded-full py-0.5 px-2 bg-gray-300'>

--- a/src/hooks/use-is-edit-view.ts
+++ b/src/hooks/use-is-edit-view.ts
@@ -15,9 +15,14 @@ export const useIsEditView = (): boolean => {
   const isEditor = pathname === '/editor'
   const isProfile =
     (pathname?.toLowerCase() === `/${userAddress?.toLowerCase()}` &&
-      selectedList === Number(profile?.primary_list)) ||
+      (profile?.primary_list && selectedList
+        ? selectedList === Number(profile?.primary_list)
+        : true)) ||
     pathname === `/${selectedList?.toString() ?? userAddress}`
 
-  const isEditView = useMemo(() => isEditor || isProfile, [pathname, isEditor, isProfile])
+  const isEditView = useMemo(
+    () => isEditor || isProfile,
+    [pathname, isEditor, isProfile, selectedList, profile]
+  )
   return isEditView
 }


### PR DESCRIPTION
- recommendations on connected user's profile when user doesn't yet have a list
- add the selected list recognition on the connected profile address page (primary list will be the only one that gets the page presented as their profile, using any other list will require you to directly look up that list page or go to the user's pagewho has this list selected as their primary list, which will in this case also treats the page as your profile