### PR TITLE
fix: theme handling based on system preferences and user choice

### DIFF
--- a/public/scripts/theme.js
+++ b/public/scripts/theme.js
@@ -5,13 +5,21 @@ if (!storedTheme || storedTheme === 'system') {
 
   if (userMedia.matches) {
     document.documentElement.classList.add('dark')
+  } else {
+    document.documentElement.classList.remove('dark')
   }
-}
-
-if (storedTheme === 'dark') {
+} else if (storedTheme === 'dark') {
   document.documentElement.classList.add('dark')
-}
-
-if (storedTheme === 'light') {
+} else if (storedTheme === 'light') {
   document.documentElement.classList.remove('dark')
 }
+
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+  if (storedTheme === 'system') {
+    if (e.matches) {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  }
+})


### PR DESCRIPTION
I’ve fixed an issue with how the theme is applied based on system preferences and user choices. Now, when `storedTheme` is set to `'system'`, it properly detects and applies the user's system theme preference. Additionally, I've added an event listener for changes in system preferences using `window.matchMedia('(prefers-color-scheme: dark)')`, so the theme is updated dynamically if the user switches their system theme. 

If the user manually selects a theme, it will be saved in `localStorage` and persist across page reloads, providing a consistent experience.