### PR TITLE
Handle missing WalletConnect project ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ bun install
 cp .env.example .env
 ```
 
+`NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID` is required for WalletConnect-backed wallet options, including
+WalletConnect QR/deep links and Rainbow/MetaMask mobile QR flows. Create a project ID in
+[Reown Cloud](https://cloud.reown.com/) (formerly WalletConnect Cloud) and add it to `.env` when you need those wallet
+options locally. The app can boot without it, but those options will be disabled.
+
 Now you should be able to run the following without getting any errors:
 
 ```bash

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -38,31 +38,46 @@ const unicornConnector = inAppWalletConnector({
 
 coinbaseWallet.preference = 'all'
 
+const walletConnectProjectId = (
+  process.env.WALLET_CONNECT_PROJECT_ID ||
+  process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ||
+  ''
+).trim()
+
+if (process.env.NODE_ENV === 'development' && !walletConnectProjectId) {
+  console.warn(
+    'NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID is not set. WalletConnect, Rainbow, and MetaMask QR/deep-link wallet options are disabled.'
+  )
+}
+
+const walletGroups = [
+  {
+    groupName: 'Recommended',
+    wallets: [coinbaseWallet, injectedWallet],
+  },
+  ...(walletConnectProjectId
+    ? [
+        {
+          groupName: 'Popular',
+          wallets: [rainbowWallet, metaMaskWallet, walletConnectWallet],
+        },
+      ]
+    : []),
+  {
+    groupName: 'Other',
+    wallets: [rabbyWallet, safeWallet],
+  },
+]
+
 // Define the connectors for the app
 // Purposely using only these for now because of a localStorage error with the Coinbase Wallet connector
-const connectors = connectorsForWallets(
-  [
-    {
-      groupName: 'Recommended',
-      wallets: [coinbaseWallet, injectedWallet],
-    },
-    {
-      groupName: 'Popular',
-      wallets: [rainbowWallet, metaMaskWallet, walletConnectWallet],
-    },
-    {
-      groupName: 'Other',
-      wallets: [rabbyWallet, safeWallet],
-    },
-  ],
-  {
-    appName: APP_NAME,
-    projectId: process.env.WALLET_CONNECT_PROJECT_ID || process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID,
-    appDescription: APP_DESCRIPTION,
-    appUrl: APP_URL,
-    appIcon: 'https://efp.app/logo.png',
-  }
-)
+const connectors = connectorsForWallets(walletGroups, {
+  appName: APP_NAME,
+  projectId: walletConnectProjectId,
+  appDescription: APP_DESCRIPTION,
+  appUrl: APP_URL,
+  appIcon: 'https://efp.app/logo.png',
+})
 
 export type ChainWithDetails = Chain & {
   iconBackground?: string

--- a/src/lib/wagmi.ts
+++ b/src/lib/wagmi.ts
@@ -38,11 +38,7 @@ const unicornConnector = inAppWalletConnector({
 
 coinbaseWallet.preference = 'all'
 
-const walletConnectProjectId = (
-  process.env.WALLET_CONNECT_PROJECT_ID ||
-  process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID ||
-  ''
-).trim()
+const walletConnectProjectId = (process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID || '').trim()
 
 if (process.env.NODE_ENV === 'development' && !walletConnectProjectId) {
   console.warn(


### PR DESCRIPTION
This prevents app startup from crashing when the WalletConnect project ID is not configured. When the ID is missing, WalletConnect-backed RainbowKit wallet options are omitted while non-WalletConnect options remain available. The README now documents when NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID is needed and where to create it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced environment variable documentation with setup requirements and wallet feature dependency information.

* **Bug Fixes**
  * WalletConnect wallet options now gracefully disable when not configured; the app continues to function normally.
  * Added development-time warning for missing wallet configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->