### PR TITLE
fix(analytics): unblock posthog identify in prod

### DIFF
--- a/src/components/posthog/posthog-identify.tsx
+++ b/src/components/posthog/posthog-identify.tsx
@@ -10,35 +10,50 @@ export default function PostHogIdentify() {
   const lastConnector = useRef<string | undefined>(undefined)
 
   useEffect(() => {
-    if (!posthog.__loaded) return
+    const run = () => {
+      if (isConnected && address) {
+        const distinctId = address.toLowerCase()
+        const connectorName = connector?.name
+        const phId = posthog.get_distinct_id?.()
+        const needsIdentify = lastAddress.current !== distinctId || phId !== distinctId
 
-    if (isConnected && address) {
-      const distinctId = address.toLowerCase()
-      const connectorName = connector?.name
+        if (needsIdentify) {
+          if (lastAddress.current && lastAddress.current !== distinctId) {
+            posthog.reset()
+          }
+          posthog.identify(distinctId, {
+            wallet_address: distinctId,
+            wallet_connector: connectorName,
+          })
+          lastAddress.current = distinctId
+          lastConnector.current = connectorName
+          return
+        }
 
-      if (lastAddress.current !== distinctId) {
-        if (lastAddress.current) posthog.reset()
-        posthog.identify(distinctId, {
-          wallet_address: distinctId,
-          wallet_connector: connectorName,
-        })
-        lastAddress.current = distinctId
-        lastConnector.current = connectorName
+        if (lastConnector.current !== connectorName) {
+          posthog.setPersonProperties({ wallet_connector: connectorName })
+          lastConnector.current = connectorName
+        }
         return
       }
 
-      if (lastConnector.current !== connectorName) {
-        posthog.setPersonProperties({ wallet_connector: connectorName })
-        lastConnector.current = connectorName
+      if (lastAddress.current) {
+        posthog.reset()
+        lastAddress.current = undefined
+        lastConnector.current = undefined
       }
+    }
+
+    if (posthog.__loaded) {
+      run()
       return
     }
 
-    if (lastAddress.current) {
-      posthog.reset()
-      lastAddress.current = undefined
-      lastConnector.current = undefined
-    }
+    const off = posthog.onFeatureFlags(() => {
+      off?.()
+      run()
+    })
+    return () => off?.()
   }, [address, isConnected, connector?.name])
 
   return null

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,8 +7,8 @@ export function middleware(request: NextRequest) {
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
 
   const cspHeader = `
-    worker-src 'self' *.cloudflareinsights.com cdn.vercel-insights.com vercel.live va.vercel-scripts.com blob:;
-    script-src 'self' *.cloudflareinsights.com cdn.vercel-insights.com vercel.live va.vercel-scripts.com www.googletagmanager.com 'unsafe-inline' 'unsafe-eval';
+    worker-src 'self' *.cloudflareinsights.com cdn.vercel-insights.com vercel.live va.vercel-scripts.com hedge.ethid.org blob:;
+    script-src 'self' *.cloudflareinsights.com cdn.vercel-insights.com vercel.live va.vercel-scripts.com www.googletagmanager.com hedge.ethid.org 'unsafe-inline' 'unsafe-eval';
     media-src 'self';
     connect-src 'self' * *.blockscout.com. wss://efp-events.up.railway.app/;
     object-src 'none';


### PR DESCRIPTION
## Summary

In prod every PostHog client event was attached to an anonymous UUID instead of the connected wallet — `$identify` never made it through. Two fixes:

- **CSP** (`src/middleware.ts`): added `hedge.ethid.org` to `script-src` and `worker-src` so posthog-js can fetch its runtime modules (`config.js`, `exception-autocapture.js`, recording worker, etc.) — capture XHRs were already passing through `connect-src '*'`, but the script-tag fetches were being blocked, leaving the SDK in a half-init state.
- **Self-healing identify** (`src/components/posthog/posthog-identify.tsx`): identify is now idempotent — it compares `posthog.get_distinct_id()` against the wallet address on every run and re-identifies when they diverge, instead of fire-once-and-forget. Replaced the `posthog.__loaded` early-return with a one-shot `posthog.onFeatureFlags` retry so an early effect tick can't silently drop the identify intent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet account detection and user identification synchronization. The system now better handles switching between wallet accounts and different wallet connectors with enhanced state management for accurate analytics tracking.

* **Chores**
  * Updated Content-Security-Policy configuration to authorize scripts from additional trusted external domains for improved service integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->